### PR TITLE
use more portable python3 interpreter location

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -1,4 +1,4 @@
-#!/Users/aviaryan/miniconda3/bin/python
+#!/usr/bin/env python3
 
 from vscode_notebook import vscode_notebook
 


### PR DESCRIPTION
The previous python interpreter location is hard coded. The change use env's python3